### PR TITLE
fix launch

### DIFF
--- a/carma-carla-integration/carma-carla-agent/agent/bridge.launch
+++ b/carma-carla-integration/carma-carla-agent/agent/bridge.launch
@@ -86,7 +86,7 @@
   <!--
     # external objects
     Extract the external objects from carla ObjectArray
-  -->>
+  -->
   <node pkg='carma_carla_bridge' type='carla_to_carma_external_objects' name='carla_to_carma_external_objects' output='screen'>
     <param name='role_name' type="str" value="$(arg role_name)"/>
   </node>

--- a/carma-carla-integration/carma-carla-agent/launch/carma_carla_agent.launch
+++ b/carma-carla-integration/carma-carla-agent/launch/carma_carla_agent.launch
@@ -27,7 +27,7 @@
   -->
 
   <arg name='agent' default='agent'/>
-  <!-- connecting default info  -->>
+  <!-- connecting default info  -->
   <arg name='host' default='127.0.0.1'/>
   <arg name='port' default='2000'/>
   <arg name='town' default='Town02'/>


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
There is extra '>' in the launch file which prevents the image from being starting. This also exists in carma-simulation-1.1.0, which I believe is carma-carla-1.1.0 docker tag image on docker hub. 

## Related Issue
https://github.com/usdot-fhwa-stol/carma-carla-integration/issues/31
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Motivation and Context
See above
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
locally smoke tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
