### PR TITLE
Negate y-axis for detected objects

### DIFF
--- a/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carla_to_carma_sensor_external_objects
+++ b/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carla_to_carma_sensor_external_objects
@@ -129,16 +129,20 @@ def create_sensor_for_sensorlib(world, api, parent_actor_id, sensor_config, nois
 
 
 def get_data_from_sensorlib(sensor):
-    
     results = sensor.get_detected_objects()
     object_msg_list = ExternalObjectList()
 
     for object in results:
         object_msg = ExternalObject()
         object_msg.id = object.id
-        position_list = object.position.tolist() 
+        position_list = object.position.tolist()
         object_msg.pose.pose.position.x = float(position_list[0])
-        object_msg.pose.pose.position.y = float(position_list[1])
+
+        # CARLA 0.9.10 has a bug where the y-axis is negated. This has
+        # been resolved in later releases. Remove the negative sign
+        # when we upgrade to a newer CARLA version.
+        object_msg.pose.pose.position.y = -float(position_list[1])
+
         object_msg.pose.pose.position.z = float(position_list[2])
         object_msg.confidence = object.confidence
         velocity_list = object.velocity.tolist()
@@ -159,7 +163,7 @@ def get_data_from_sensorlib(sensor):
 
     external_objects_pub.publish(object_msg_list)
 
-    
+
 
 if __name__ == '__main__':
     print("carla_to_carma_sensor_external_objects")


### PR DESCRIPTION
# PR Details
## Description

This PR locally patches a bug in CARLA 0.9.10 where actors' locations have negated y-values. The patch multiplies the y-values by negative one.

> [!NOTE]\
> This patch is only necessary for CARLA 0.9.10. The problem was resolved in future CARLA releases.

## Related GitHub Issue

Closes #46 

## Related Jira Key

Closes [CDAR-514](https://usdot-carma.atlassian.net/browse/CDAR-514)

## Motivation and Context

Necessary patch for third-party issue

## How Has This Been Tested?

Manual integration testing

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[CDAR-514]: https://usdot-carma.atlassian.net/browse/CDAR-514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ