### PR TITLE
Add sensor orientation information to generated external object list messages

### DIFF
--- a/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carla_to_carma_sensor_external_objects
+++ b/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carla_to_carma_sensor_external_objects
@@ -13,16 +13,19 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-#sensorlib imports
+
 import sys
+
 sys.path.append('/home/carma/utils/carma-utils/sensorlib')
 from src.CarlaCDASimAPI import CarlaCDASimAPI
 from src.util.SimulatedSensorUtils import SimulatedSensorUtils
 import carla
+
+from cav_msgs.msg import ExternalObjectList, ExternalObject
+import numpy as np
 import rospy
 from rospy.exceptions import ROSInterruptException
-import numpy as np
-from cav_msgs.msg import ExternalObjectList, ExternalObject
+from scipy.spatial.transform import Rotation
 
 external_objects_pub = rospy.Publisher('/environment/external_objects', ExternalObjectList, queue_size=1)
 
@@ -147,6 +150,15 @@ def get_data_from_sensorlib(sensor):
         object_msg.pose.pose.position.x = float(position_list[0])
         object_msg.pose.pose.position.y = float(position_list[1])
         object_msg.pose.pose.position.z = float(position_list[2])
+
+        roll, pitch, yaw = object.rotation
+        rotation = Rotation.from_euler("xyz", [roll, pitch, yaw], degrees=True)
+        quaternion = rotation.as_quat()
+
+        object_msg.pose.pose.orientation.x = quaternion[0]
+        object_msg.pose.pose.orientation.y = quaternion[1]
+        object_msg.pose.pose.orientation.z = quaternion[2]
+        object_msg.pose.pose.orientation.w = quaternion[3]
 
         zeros_3_3 = np.zeros((3,3),dtype=float) # Create off-diagonal zeros array
         pose_covariance = np.asarray(np.bmat([[object.positionCovariance, zeros_3_3], [zeros_3_3, object.orientationCovariance]]))


### PR DESCRIPTION
# PR Details
## Description

This PR adds orientation information to the generated external object list messages coming from the sensorlib sensors.

## Related GitHub Issue

Closes #51 

## Related Jira Key

Closes [CDAR-553](https://usdot-carma.atlassian.net/browse/CDAR-533)
Closes [CDAR-552](https://usdot-carma.atlassian.net/browse/CDAR-552)

## Motivation and Context

The default values for orientation (all zeros) cause Euler angle conversion errors for downstream nodes that don't check for valid quaternions.

## How Has This Been Tested?

Manually tested.

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.


[CDAR-552]: https://usdot-carma.atlassian.net/browse/CDAR-552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CDAR-553]: https://usdot-carma.atlassian.net/browse/CDAR-553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ