### PR TITLE
Add frame ID to external object list header

### DIFF
--- a/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carla_to_carma_sensor_external_objects
+++ b/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carla_to_carma_sensor_external_objects
@@ -136,6 +136,7 @@ def get_data_from_sensorlib(sensor):
 
     results = sensor.get_detected_objects()
     object_msg_list = ExternalObjectList()
+    object_msg_list.header.frame_id = "map"
 
     for object in results:
         object_msg = ExternalObject()


### PR DESCRIPTION
# PR Details
## Description

This PR adds the `map` frame ID to the external object list messages published by the `carla_to_carma_sensor_external_objects` node. The change was needed because downstream visualizer nodes would not have their generated markers displayed.

## Related GitHub Issue

Closes #59 

## Related Jira Key

Closes [CDAR-620](https://usdot-carma.atlassian.net/browse/CDAR-620)

## Motivation and Context

Bug fix

## How Has This Been Tested?

Manually in integration test.

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.


[CDAR-620]: https://usdot-carma.atlassian.net/browse/CDAR-620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ