### PR TITLE
Add debug logging for failure conditions

### DIFF
--- a/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
+++ b/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
@@ -119,12 +119,20 @@ def initialize():
                 continue
 
             if resp.guidance_status:
-                rospy.loginfo("Guidance engaged!")
+                rospy.loginfo("Guidance engaged")
                 break
             else:
                 rospy.logerr("Failed to set guidance status")
-        else:
-            rospy.sleep(1)
+                continue
+
+        if not route_selected:
+            rospy.logdebug("Could not engage guidance: route not selected")
+
+        if not check_plugin_status(active_plugins, plugin_list):
+            rospy.logdebug("Could not engage guidance: missing some required plugins")
+            rospy.logdebug(f"Active plugins: {', '.join([plugin.name for plugin in active_plugins])}")
+
+        rospy.sleep(1)
 
 if __name__ == '__main__':
     rospy.loginfo("carma_carla_guidance starting")


### PR DESCRIPTION
# PR Details
## Description

This PR adds some extra logging printouts for the `carma_carla_guidance` node. Attempts to enable CARMA's guidance system can fail if there is no route selected or when plugin checks fail. Under these conditions, there is no logging. This PR adds debug-level logs to those failure conditions.

## Related GitHub Issue

Closes #61 

## Related Jira Key

Closes [CDAR-624](https://usdot-carma.atlassian.net/browse/CDAR-624)

## Motivation and Context

See above

## How Has This Been Tested?

## Types of changes

- [x] New feature (non-breaking change that adds functionality)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.


[CDAR-624]: https://usdot-carma.atlassian.net/browse/CDAR-624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ