### PR TITLE
Checkout carla-sensor-lib instead of carma utils

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 name: CI
 on:
-  push:
   pull_request:
-      types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [develop, master]
 jobs:
   build:
     defaults:
@@ -37,8 +38,6 @@ jobs:
       with:
         java-version: 17
         distribution: "temurin"
-        run: |
-          export JAVA_HOME=$GITHUB_WORKSPACE/java-17
     - name: Checkout carma-msgs
       uses: actions/checkout@v3.3.0
       with:
@@ -49,6 +48,7 @@ jobs:
     - name: Build
       run: |
         source "$INIT_ENV"
+        export JAVA_HOME=$GITHUB_WORKSPACE/java-17
         sed -i '/colcon build/ s/$/ --packages-up-to carla_sensors_integration carma_carla_agent carma_carla_bridge/' /home/carma/.ci-image/engineering_tools/code_coverage/make_with_coverage.bash
         make_with_coverage.bash -m -e /opt/carma/ -o ./coverage_reports/gcov
     - name: Run C++ Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,13 @@ jobs:
       with:
         repository: usdot-fhwa-stol/carma-utils
         path: src/carma-utils
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3 # The setup-java action provides the functionality for GitHub Actions runners for Downloading and setting up a requested version of Java
+      with:
+        java-version: 17
+        distribution: "temurin"
+        run: |
+          export JAVA_HOME=$GITHUB_WORKSPACE/java-17
     - name: Checkout carma-msgs
       uses: actions/checkout@v3.3.0
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,11 @@ jobs:
       with:
         repository: usdot-fhwa-stol/autoware.ai
         path: src/autoware.ai
-    - name: Checkout carma-utils
+    - name: Checkout carla-sensor-lib
       uses: actions/checkout@v3.3.0
       with:
-        repository: usdot-fhwa-stol/carma-utils
-        path: src/carma-utils
+        repository: usdot-fhwa-stol/carla-sensor-lib
+        path: src/carla-sensor-lib
     - name: Checkout carma-msgs
       uses: actions/checkout@v3.3.0
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,11 @@ jobs:
       with:
         repository: usdot-fhwa-stol/autoware.ai
         path: src/autoware.ai
-    - name: Checkout carla-sensor-lib
+    - name: Checkout carma-utils
       uses: actions/checkout@v3.3.0
       with:
-        repository: usdot-fhwa-stol/carla-sensor-lib
-        path: src/carla-sensor-lib
+        repository: usdot-fhwa-stol/carma-utils
+        path: src/carma-utils
     - name: Checkout carma-msgs
       uses: actions/checkout@v3.3.0
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,6 @@ jobs:
       with:
         repository: usdot-fhwa-stol/carma-utils
         path: src/carma-utils
-    - name: Set up JDK 17
-      uses: actions/setup-java@v3 # The setup-java action provides the functionality for GitHub Actions runners for Downloading and setting up a requested version of Java
-      with:
-        java-version: 17
-        distribution: "temurin"
     - name: Checkout carma-msgs
       uses: actions/checkout@v3.3.0
       with:
@@ -48,7 +43,6 @@ jobs:
     - name: Build
       run: |
         source "$INIT_ENV"
-        export JAVA_HOME=$GITHUB_WORKSPACE/java-17
         sed -i '/colcon build/ s/$/ --packages-up-to carla_sensors_integration carma_carla_agent carma_carla_bridge/' /home/carma/.ci-image/engineering_tools/code_coverage/make_with_coverage.bash
         make_with_coverage.bash -m -e /opt/carma/ -o ./coverage_reports/gcov
     - name: Run C++ Tests

--- a/.sonarqube/sonar-scanner.properties
+++ b/.sonarqube/sonar-scanner.properties
@@ -48,3 +48,6 @@ PythonAPI.sonar.sources = .
 # Tests
 # Note: For C++ setting this field does not cause test analysis to occur. It only allows the test source code to be evaluated.
 carla_sensors_integration.sonar.tests = test
+# Force analysis on depreciated Java Version 11
+# TODO: Update java version for carma-base to 17
+sonar.scanner.force-deprecated-java-version = true

--- a/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carla_to_carma_sensor_external_objects
+++ b/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carla_to_carma_sensor_external_objects
@@ -16,7 +16,7 @@
 
 import sys
 
-sys.path.append('/home/carma/utils/carma-utils/sensorlib')
+sys.path.append('/home/carma/carla-sensor-lib')
 from src.CarlaCDASimAPI import CarlaCDASimAPI
 from src.util.SimulatedSensorUtils import SimulatedSensorUtils
 import carla
@@ -81,10 +81,10 @@ def setup_carla_client_and_config():
     api = CarlaCDASimAPI.build_from_world(world)
 
     sensor_config = SimulatedSensorUtils.load_config_from_file(
-        "/home/carma/utils/carma-utils/sensorlib/config/simulated_sensor_config.yaml"
+        "/home/carma/carla-sensor-lib/config/simulated_sensor_config.yaml"
     )
     noise_model_config = SimulatedSensorUtils.load_config_from_file(
-        "/home/carma/utils/carma-utils/sensorlib/config/noise_model_config.yaml"
+        "/home/carma/carla-sensor-lib/config/noise_model_config.yaml"
     )
     #change sensor config to non sensor centric
     sensor_config["simulated_sensor"]["use_sensor_centric_frame"] = False

--- a/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carla_to_carma_sensor_external_objects
+++ b/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carla_to_carma_sensor_external_objects
@@ -81,10 +81,10 @@ def setup_carla_client_and_config():
     api = CarlaCDASimAPI.build_from_world(world)
 
     sensor_config = SimulatedSensorUtils.load_config_from_file(
-        "/home/carma/utils/carma-utils/sensorlib/config/simulated_sensor_config.yaml"
+        "/home/carma/carla-sensor-lib/config/simulated_sensor_config.yaml"
     )
     noise_model_config = SimulatedSensorUtils.load_config_from_file(
-        "/home/carma/utils/carma-utils/sensorlib/config/noise_model_config.yaml"
+        "/home/carma/carla-sensor-lib/config/noise_model_config.yaml"
     )
     #change sensor config to non sensor centric
     sensor_config["simulated_sensor"]["use_sensor_centric_frame"] = False

--- a/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carla_to_carma_sensor_external_objects
+++ b/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carla_to_carma_sensor_external_objects
@@ -16,7 +16,7 @@
 
 import sys
 
-sys.path.append('/home/carma/carla-sensor-lib')
+sys.path.append('/home/carma/sensorlib')
 from src.CarlaCDASimAPI import CarlaCDASimAPI
 from src.util.SimulatedSensorUtils import SimulatedSensorUtils
 import carla
@@ -81,10 +81,10 @@ def setup_carla_client_and_config():
     api = CarlaCDASimAPI.build_from_world(world)
 
     sensor_config = SimulatedSensorUtils.load_config_from_file(
-        "/home/carma/carla-sensor-lib/config/simulated_sensor_config.yaml"
+        "/home/carma/utils/carma-utils/sensorlib/config/simulated_sensor_config.yaml"
     )
     noise_model_config = SimulatedSensorUtils.load_config_from_file(
-        "/home/carma/carla-sensor-lib/config/noise_model_config.yaml"
+        "/home/carma/utils/carma-utils/sensorlib/config/noise_model_config.yaml"
     )
     #change sensor config to non sensor centric
     sensor_config["simulated_sensor"]["use_sensor_centric_frame"] = False

--- a/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carla_to_carma_sensor_external_objects
+++ b/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carla_to_carma_sensor_external_objects
@@ -16,7 +16,7 @@
 
 import sys
 
-sys.path.append('/home/carma/sensorlib')
+sys.path.append('/home/carma/carla-sensor-lib')
 from src.CarlaCDASimAPI import CarlaCDASimAPI
 from src.util.SimulatedSensorUtils import SimulatedSensorUtils
 import carla

--- a/docker/checkout.sh
+++ b/docker/checkout.sh
@@ -37,8 +37,6 @@ done
 
 if [[ "$BRANCH" = "develop" ]]; then
       git clone https://github.com/usdot-fhwa-stol/carma-msgs.git ~/src/carma-msgs --branch $BRANCH --depth 1
-      git clone https://github.com/usdot-fhwa-stol/carma-utils.git ~/src/carma-utils --branch $BRANCH --depth 1    
 else
       git clone https://github.com/usdot-fhwa-stol/carma-msgs.git ${dir}/src/carma-msgs --branch develop --depth 1
-      git clone https://github.com/usdot-fhwa-stol/carma-utils.git ${dir}/src/carma-utils --branch develop --depth 1
 fi

--- a/docker/checkout.sh
+++ b/docker/checkout.sh
@@ -37,6 +37,8 @@ done
 
 if [[ "$BRANCH" = "develop" ]]; then
       git clone https://github.com/usdot-fhwa-stol/carma-msgs.git ~/src/carma-msgs --branch $BRANCH --depth 1
+      git clone https://github.com/usdot-fhwa-stol/carma-utils.git ~/src/carma-utils --branch $BRANCH --depth 1    
 else
       git clone https://github.com/usdot-fhwa-stol/carma-msgs.git ${dir}/src/carma-msgs --branch develop --depth 1
+      git clone https://github.com/usdot-fhwa-stol/carma-utils.git ${dir}/src/carma-utils --branch develop --depth 1
 fi

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -41,9 +41,12 @@ else
 fi
 cd ~/msgs && sudo git clone --depth 1 --single-branch -b ${CARMA_VERSION} https://github.com/usdot-fhwa-stol/carma-msgs.git
 
-# CARLA Sensor Lib package
-cd /opt/
-sudo git clone --depth 1 --single-branch -b ${CARMA_VERSION} https://github.com/usdot-fhwa-stol/carla-sensor-lib.git
+# CARMA Utils package
+mkdir -p ~/utils
+cd ~/utils && sudo git clone --depth 1 --single-branch -b ${CARMA_VERSION} https://github.com/usdot-fhwa-stol/carma-utils.git
+# CARLA Sensor Lib 
+cd ~
+sudo git clone --depth 1 --single-branch -b ${CARMA_VERSION} https://github.com/usdot-fhwa-stol/carla-sensor-lib
 
 # GPS Common
 mkdir -p ~/gps && cd ~/gps 
@@ -59,8 +62,8 @@ ln -s ~/msgs/carma-msgs/cav_srvs
 ln -s ~/msgs/carma-msgs/carma_cmake_common
 ln -s ~/msgs/autoware.ai/messages/autoware_msgs
 
-cd ~/carma_carla_ws/
-ln -s ~/opt/carla-sensor-lib
+mkdir -p ~/carma_carla_ws/src/utils && cd ~/carma_carla_ws/src/utils 
+ln -s ~/utils/carma-utils/carma_utils
 
 cd ~/carma_carla_ws/src && 
 ln -s ~/ros-bridge

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -41,9 +41,9 @@ else
 fi
 cd ~/msgs && sudo git clone --depth 1 --single-branch -b ${CARMA_VERSION} https://github.com/usdot-fhwa-stol/carma-msgs.git
 
-# CARMA Utils package
-mkdir -p ~/utils
-cd ~/utils && sudo git clone --depth 1 --single-branch -b ${CARMA_VERSION} https://github.com/usdot-fhwa-stol/carma-utils.git
+# CARLA Sensor Lib package
+cd /opt/
+sudo git clone --depth 1 --single-branch -b ${CARMA_VERSION} https://github.com/usdot-fhwa-stol/carla-sensor-lib.git
 
 # GPS Common
 mkdir -p ~/gps && cd ~/gps 
@@ -59,8 +59,8 @@ ln -s ~/msgs/carma-msgs/cav_srvs
 ln -s ~/msgs/carma-msgs/carma_cmake_common
 ln -s ~/msgs/autoware.ai/messages/autoware_msgs
 
-mkdir -p ~/carma_carla_ws/src/utils && cd ~/carma_carla_ws/src/utils 
-ln -s ~/utils/carma-utils/carma_utils
+cd ~/carma_carla_ws/
+ln -s ~/opt/carla-sensor-lib
 
 cd ~/carma_carla_ws/src && 
 ln -s ~/ros-bridge

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -30,27 +30,27 @@ sudo python3 -m pip install simple-pid==1.0.1 wheel numpy
 sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 
 # Clone CARLA ROS bridge
-sudo git clone --depth 1 -b '0.9.10.1' --recurse-submodules https://github.com/carla-simulator/ros-bridge.git
+git clone --depth 1 -b '0.9.10.1' --recurse-submodules https://github.com/carla-simulator/ros-bridge.git
 
 # Clone ROS message
 mkdir -p ~/msgs
 if [ "${CARMA_VERSION}" = "develop" ]; then
-  cd ~/msgs && sudo git clone --depth 1 --single-branch -b carma-develop https://github.com/usdot-fhwa-stol/autoware.ai.git
+  cd ~/msgs && git clone --depth 1 --single-branch -b carma-develop https://github.com/usdot-fhwa-stol/autoware.ai.git
 else
-  cd ~/msgs && sudo git clone --depth 1 --single-branch -b ${CARMA_VERSION} https://github.com/usdot-fhwa-stol/autoware.ai.git
+  cd ~/msgs && git clone --depth 1 --single-branch -b ${CARMA_VERSION} https://github.com/usdot-fhwa-stol/autoware.ai.git
 fi
-cd ~/msgs && sudo git clone --depth 1 --single-branch -b ${CARMA_VERSION} https://github.com/usdot-fhwa-stol/carma-msgs.git
+cd ~/msgs && git clone --depth 1 --single-branch -b ${CARMA_VERSION} https://github.com/usdot-fhwa-stol/carma-msgs.git
 
 # CARMA Utils package
 mkdir -p ~/utils
-cd ~/utils && sudo git clone --depth 1 --single-branch -b ${CARMA_VERSION} https://github.com/usdot-fhwa-stol/carma-utils.git
+cd ~/utils && git clone --depth 1 --single-branch -b ${CARMA_VERSION} https://github.com/usdot-fhwa-stol/carma-utils.git
 # CARLA Sensor Lib 
 cd ~
-sudo git clone --depth 1 --single-branch -b ${CARMA_VERSION} https://github.com/usdot-fhwa-stol/carla-sensor-lib
+git clone --depth 1 --single-branch -b ${CARMA_VERSION} https://github.com/usdot-fhwa-stol/carla-sensor-lib
 
 # GPS Common
 mkdir -p ~/gps && cd ~/gps 
-sudo git clone https://github.com/swri-robotics/gps_umd.git
+git clone https://github.com/swri-robotics/gps_umd.git
 
 mkdir -p ~/carma_carla_ws/src/msgs && cd ~/carma_carla_ws/src/msgs
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
**carla-sensor-lib** has been moved from carma-utils GitHub repository to its own [carla-sensor-lib](https://github.com/usdot-fhwa-stol/carla-sensor-lib) repository. **carma-carla-integration** depends on **carla-sensor-lib**. This PR updates the build and python scripts to used the new repository.
<!--- Describe your changes in detail -->
**NOTE: This PR requires the change set in https://github.com/usdot-fhwa-stol/carla-sensor-lib/pull/4 to be merged into develop or equivalent change in docker-compose system path**
## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
[CDAR-722](https://usdot-carma.atlassian.net/browse/CDAR-722)
<!-- e.g. CAR-123 -->

## Motivation and Context
Accommodate moving of sensor lib into its own repository [carla-sensor-lib](https://github.com/usdot-fhwa-stol/carla-sensor-lib)
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Build carma-carla-integration tool and confirm it the `carla_to_carma_sensor_external_objects` service does not die inside the **carma-carla-integration** docker image. 
Example of logs that indicate service is dying
```
Traceback (most recent call last):
  File "/home/carma/carma_carla_ws/src/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carla_to_carma_sensor_external_objects", line 20, in <module>
    from src.CarlaCDASimAPI import CarlaCDASimAPI
  File "/home/carma/carla-sensor-lib/src/CarlaCDASimAPI.py", line 14, in <module>
    from util.CarlaLoader import CarlaLoader
ModuleNotFoundError: No module named 'util'
[carla_to_carma_sensor_external_objects-14] process has died [pid 391, exit code 1, cmd /home/carma/carma_carla_ws/src/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carla_to_carma_sensor_external_objects __name:=carla_to_carma_sensor_external_objects __log:=/opt/carma/logs/abadff08-b4ae-11ee-90c0-0242ac030002/carla_to_carma_sensor_external_objects-14.log].
log file: /opt/carma/logs/abadff08-b4ae-11ee-90c0-0242ac030002/carla_to_carma_sensor_external_objects-14*.log
```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes


<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[CDAR-722]: https://usdot-carma.atlassian.net/browse/CDAR-722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ