### PR TITLE
CDAS-57 Carma to Carla Ackermann_Cmd Node

### DIFF
--- a/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_to_carla_ackermann_cmd
+++ b/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_to_carla_ackermann_cmd
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # Copyright (C) 2021 LEIDOS.
+# Ported to ROS2 by Will Varner under UGA's MSC Lab
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -24,7 +25,6 @@
 # This work is licensed under the terms of the MIT license.
 # For a copy, see <https://opensource.org/licenses/MIT>.
 #
-
 """
 Subscribe from CARMA :autoware_msgs::VehicleCmd
     Topic: /hardware_interface/vehicle_cmd
@@ -37,84 +37,114 @@ Subscribe from CARMA :cav_msgs::GuidanceState
 
 Publish to CARLA :ackermann_msgs::AckermannDrive
     Topic: /carla/{}/ackermann_cmd
-
 """
-import rospy
+
+import rclpy
+from rclpy.node import Node
+
+# Import message types
 from ackermann_msgs.msg import AckermannDrive
 from autoware_msgs.msg import VehicleCmd
 from cav_msgs.msg import GuidanceState
 from std_msgs.msg import Float32
 
-ackermann_cmd_pub = None
-guidance_state = GuidanceState.STARTUP
-init_status = True
-init_cmd = AckermannDrive()
-lateral_jerk = 0
+class CarmaToCarlaAckermannCmd(Node):
+    def __init__(self):
+        super().__init__('carma_to_carla_ackermann_cmd_node')
 
-def guidance_state_callback(guidance_state_msg):
-    """
-    callback for guidance state subscribing from CARMA
-    guidance_state_msg type:
-        cav_msgs::GuidanceState
-    """
-    global init_status, guidance_state, init_cmd, ackermann_cmd_pub
+        # Initialize state variables
+        self.guidance_state = GuidanceState.STARTUP
+        self.init_status = True
+        self.lateral_jerk = 0.0
 
-    guidance_state = guidance_state_msg.state
-    if guidance_state == GuidanceState.ENGAGED and init_status:
-        init_status = False
-        ## providing initial ackermann command to carla virtual vehicle
-        init_cmd.speed = rospy.get_param('~init_speed', 10)
-        init_cmd.acceleration = rospy.get_param('~init_acceleration', 1)
-        init_cmd.steering_angle = rospy.get_param('~init_steering_angle', 0)
-        init_cmd.jerk = rospy.get_param('~init_jerk', 0)
-        ackermann_cmd_pub.publish(init_cmd)
+        # Declare all parameters
+        self.role_name = self.declare_parameter('role_name', 'ego_vehicle').get_parameter_value().string_value
+        self.declare_parameter('init_speed', 10.0)
+        self.declare_parameter('init_acceleration', 1.0)
+        self.declare_parameter('init_steering_angle', 0.0)
+        self.declare_parameter('init_jerk', 0.0)
+        
+        self.get_logger().info(f"Node 'carma_to_carla_ackermann_cmd_node' started for vehicle '{self.role_name}'.")
 
-def commanded_jerk_callback(lateral_jerk_msg):
-    """
-    callback for commanded jerk from CARMA
-    lateral_jerk_msg type:
-        std_msgs::Float32
-    """
+        # Create Publisher
+        self.ackermann_cmd_pub = self.create_publisher(
+            AckermannDrive,
+            f'/carla/{self.role_name}/ackermann_cmd',
+            1)
 
-    global lateral_jerk
-    lateral_jerk = lateral_jerk_msg.data
+        # Create Subscribers
+        self.vehicle_cmd_sub = self.create_subscription(
+            VehicleCmd,
+            '/hardware_interface/vehicle_cmd',
+            self.vehicle_cmd_callback,
+            1)
 
-def vehicle_cmd_callback(vehicle_cmd):
-    """
-    callback for vehicle cmds subscribing from CARMA
-    vehicle_cmd type:
-        autoware_msgs::VehicleCmd
-    """
-    global ackermann_cmd_pub
-    if guidance_state != GuidanceState.ENGAGED:
-        return
-    else:
+        self.guidance_state_sub = self.create_subscription(
+            GuidanceState,
+            '/guidance/state',
+            self.guidance_state_callback,
+            1)
+
+        self.jerk_sub = self.create_subscription(
+            Float32,
+            '/guidance/twist_filter/result/twist/lateral_jerk',
+            self.commanded_jerk_callback,
+            1)
+
+    def guidance_state_callback(self, guidance_state_msg):
+        """
+        Callback for guidance state subscribing from CARMA.
+        """
+        self.guidance_state = guidance_state_msg.state
+        if self.guidance_state == GuidanceState.ENGAGED and self.init_status:
+            self.init_status = False
+            
+            # Get initial command parameters
+            init_speed = self.get_parameter('init_speed').get_parameter_value().double_value
+            init_accel = self.get_parameter('init_acceleration').get_parameter_value().double_value
+            init_steer = self.get_parameter('init_steering_angle').get_parameter_value().double_value
+            init_jerk = self.get_parameter('init_jerk').get_parameter_value().double_value
+            
+            # Create and publish the initial command
+            init_cmd = AckermannDrive()
+            init_cmd.speed = init_speed
+            init_cmd.acceleration = init_accel
+            init_cmd.steering_angle = init_steer
+            init_cmd.jerk = init_jerk
+            self.ackermann_cmd_pub.publish(init_cmd)
+            self.get_logger().info("Guidance engaged, publishing initial Ackermann command.")
+
+    def commanded_jerk_callback(self, lateral_jerk_msg):
+        """
+        Callback for commanded jerk from CARMA.
+        """
+        self.lateral_jerk = lateral_jerk_msg.data
+
+    def vehicle_cmd_callback(self, vehicle_cmd):
+        """
+        Callback for vehicle cmds subscribing from CARMA.
+        """
+        if self.guidance_state != GuidanceState.ENGAGED:
+            return
+        
         ackermann_drive = AckermannDrive()
         ackermann_drive.speed = vehicle_cmd.ctrl_cmd.linear_velocity
         ackermann_drive.acceleration = vehicle_cmd.ctrl_cmd.linear_acceleration
         ackermann_drive.steering_angle = vehicle_cmd.ctrl_cmd.steering_angle
-        ackermann_drive.jerk = lateral_jerk
+        ackermann_drive.jerk = self.lateral_jerk
 
-        ## publishing ackermann drive msg to CARLA virtual vehicle
-        ackermann_cmd_pub.publish(ackermann_drive)
+        self.ackermann_cmd_pub.publish(ackermann_drive)
 
-
-def vehicle_cmd_to_ackermanndrive():
-    """
-    mainloop
-    """
-    global ackermann_cmd_pub
-    rospy.init_node('carma_to_carla_vehicle_cmd')
-    role_name = rospy.get_param('~role_name', 'ego_vehicle')
-    # pub init
-    ackermann_cmd_pub = rospy.Publisher('/carla/{}/ackermann_cmd'.format(role_name), AckermannDrive, queue_size=1)
-    # sub init
-    rospy.Subscriber('/hardware_interface/vehicle_cmd', VehicleCmd, vehicle_cmd_callback, queue_size=1)
-    rospy.Subscriber('/guidance/state', GuidanceState, guidance_state_callback, queue_size=1)
-    rospy.Subscriber('/guidance/twist_filter/result/twist/lateral_jerk', Float32, commanded_jerk_callback, queue_size=1)
-    rospy.spin()
-
+def main(args=None):
+    rclpy.init(args=args)
+    node = CarmaToCarlaAckermannCmd()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
 
 if __name__ == '__main__':
-    print("carma_to_carla_vehicle_cmd")
-    vehicle_cmd_to_ackermanndrive()
+    main()


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

This PR ports the `carma_to_carla_ackermann_cmd.py` script from ROS 1 (rospy) to ROS 2 (rclpy). This node subscribes to CARMA Platform's vehicle command topic and translates it into an `ackermann_msgs/AckermannDrive` message.

## Related Jira Key

CDAS-57

## Motivation and Context

This change is required as part of the larger effort to migrate CARMA-CARLA integration components from ROS 1 to ROS 2, as outlined in the project's upgrade plan. With this PR, now another component will work properly with ROS 2 Humble.

## How Has This Been Tested?

**NOTE: This node / testing requires ROS 2 compatible autoware_msgs and cav_msgs being present in the production build environment. For testing purposes, I cloned these messages and ported them to ROS 2 myself, changing header formats and other minor syntax, yet the message files purpose and logic remain virtually identical**

The ported node was tested locally in a ROS 2 Humble workspace. The testing process was as follows:

1. A temporary ROS 2 package (local_carma_msgs) was created to provide the necessary VehicleCmd and GuidanceState message definitions.

2. The node was launched using ros2 run carma_ackermann_driver carma_to_carla_ackermann_cmd.

3. The node's inputs were simulated using ros2 topic pub. This included publishing to /guidance/state to engage guidance and to /hardware_interface/vehicle_cmd to send control commands.

4. The node's output was verified using ros2 topic echo on /carla/ego_vehicle/ackermann_cmd.

The tests confirmed that the node correctly subscribed to topics, processed data based on the guidance state, and published the expected AckermannDrive messages, mirroring the functionality of the original ROS 1 script. I'll also upload a video test to Jira.

![CDAS-57-Terminal-Test](https://github.com/user-attachments/assets/3394d6f2-db03-4dd7-97e9-61167dca7ee8)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
