### PR TITLE
Cdas 53 carma carla guidance

### DIFF
--- a/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
+++ b/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
@@ -105,11 +105,11 @@ class CarmaCarlaGuidance(Node):
                     break
             else:
                 if not self.route_selected:
-                    self.get_logger().debug("Could not engage guidance: route not selected")
+                    self.get_logger().warn("Could not engage guidance: route not selected")
                 if not self.check_plugin_status(active_plugins):
                     active_names = [plugin.name for plugin in active_plugins]
-                    self.get_logger().debug("Could not engage guidance: missing some required plugins")
-                    self.get_logger().debug(f"Active plugins: {active_names}")
+                    self.get_logger().warn("Could not engage guidance: missing some required plugins")
+                    self.get_logger().warn(f"Active plugins: {active_names}")
     
     def engage_guidance(self):
         seconds_passed = 0.0

--- a/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
+++ b/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
@@ -51,9 +51,6 @@ class CarmaCarlaGuidance(Node):
             )
             return
         
-        # create loop rate timer
-        self.main_loop_rate = self.create_rate(1.0)
-        
          # route selected state
         self.route_selected = False
 
@@ -78,6 +75,11 @@ class CarmaCarlaGuidance(Node):
 
         # Main loop
         while rclpy.ok():
+            
+            start_time = time.time()
+            while time.time() - start_time < 1.0:
+                rclpy.spin_once(self, timeout_sec=1.0)
+            
             # Publish active status
             status_msg = Bool()
             status_msg.data = True
@@ -108,9 +110,6 @@ class CarmaCarlaGuidance(Node):
                     active_names = [plugin.name for plugin in active_plugins]
                     self.get_logger().warn("Could not engage guidance: missing some required plugins")
                     self.get_logger().warn(f"Active plugins: {active_names}")
-            
-            # Sleep for 1 second while allowing callbacks
-            self.main_loop_rate.sleep()
     
     def engage_guidance(self):
         seconds_passed = 0.0

--- a/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
+++ b/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
@@ -26,6 +26,7 @@ from rclpy.node import Node
 
 import ast
 import time
+import traceback
 
 from cav_msgs.msg import RouteEvent
 from cav_msgs.msg import Plugin
@@ -131,3 +132,25 @@ class CarmaCarlaGuidance(Node):
         if msg.event == RouteEvent.ROUTE_SELECTED or msg.event == RouteEvent.ROUTE_STARTED:
             self.get_logger().info("Route Selected")
             self.route_selected = True
+
+def main(args=None):
+    rclpy.init(args=args)
+    print("carma_carla_guidance")
+    try:
+        node = CarmaCarlaGuidance()
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        if node: node.get_logger().info(f"{node.get_name()} shutting down due to KeyboardInterrupt.")
+    except Exception as e:
+        # Ensure logger is available or use print
+        logger = rclpy.logging.get_logger("carma_carla_guidance_main")
+        if node : logger = node.get_logger()
+        logger.error(f"Unhandled exception in {node.get_name() if node else 'carma_carla_guidance'}: {e}\n{traceback.format_exc()}")
+    finally:
+        if node:
+            node.destroy_node()
+        if rclpy.ok():
+            rclpy.shutdown()
+
+if __name__ == '__main__':
+    main()

--- a/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
+++ b/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
@@ -127,6 +127,11 @@ class CarmaCarlaGuidance(Node):
         self.get_logger().info("All plugins activated...!")
         return True
     
+    def route_event_callback(self, msg):
+        if msg.event == RouteEvent.ROUTE_SELECTED or msg.event == RouteEvent.ROUTE_STARTED:
+            self.get_logger().info("Route Selected")
+            self.route_selected = True
+    
 route_selected = False
 
 def route_event_callback(route_event_msg):

--- a/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
+++ b/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
@@ -80,7 +80,7 @@ class CarmaCarlaGuidance(Node):
         while rclpy.ok():
             
             start_time = time.time()
-            while time.time() - start_time < 1.5:
+            while time.time() - start_time < 1.0:
                 rclpy.spin_once(self, timeout_sec=1.0)
             
             # Publish active status
@@ -92,7 +92,11 @@ class CarmaCarlaGuidance(Node):
             try:
                 plugins_request = PluginList.Request()
                 plugins_future = self.get_active_plugins_client.call_async(plugins_request)
-                rclpy.spin_until_future_complete(self, plugins_future)
+                rclpy.spin_until_future_complete(self, plugins_future, timeout_sec=2.0)
+
+                if not plugins_future.done():
+                    self.get_logger().warn(f"Service call to {self.get_active_plugins_client.srv_name} timed out.")
+                    continue
             except Exception as e:
                 self.get_logger().warn(f"Service call to {self.get_active_plugins_client.srv_name} failed: {e}")
                 self.get_logger().warn("Service call can sometimes fail due to ROS, but please make sure the selected plugins are activated. Retrying in 1 second..")

--- a/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
+++ b/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
@@ -94,12 +94,11 @@ class CarmaCarlaGuidance(Node):
                 if not plugins_future.done():
                     self.get_logger().warn(f"Service call to {self.get_active_plugins_client.srv_name} timed out.")
                     continue
+                active_plugins = plugins_future.result().plugins
             except Exception as e:
                 self.get_logger().warn(f"Service call to {self.get_active_plugins_client.srv_name} failed: {e}")
                 self.get_logger().warn("Service call can sometimes fail due to ROS, but please make sure the selected plugins are activated. Retrying in 1 second..")
                 continue
-
-            active_plugins = plugins_future.result().plugins
 
             if self.route_selected and self.check_plugin_status(active_plugins):
                 if self.engage_guidance():

--- a/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
+++ b/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
@@ -70,35 +70,36 @@ class CarmaCarlaGuidance(Node):
         self.set_guidance_active_client.wait_for_service()
         self.get_active_plugins_client.wait_for_service()
 
-        # Set main loop
-        self.timer = self.create_timer(1.0, self.timer_callback)
+        # Main loop
+        while rclpy.ok():
+            rclpy.spin_once(self, timeout_sec=1.5)
+            
+            # Publish active status
+            status_msg = Bool()
+            status_msg.data = True
+            self.status_pub.publish(status_msg)
 
-    def timer_callback(self):
-        # Publish active status
-        status_msg = Bool()
-        status_msg.data = True
-        self.status_pub.publish(status_msg)
+            # Call get_active_plugins service synchronously
+            plugins_request = PluginList.Request()
+            plugins_future = self.get_active_plugins_client.call_async(plugins_request)
+            rclpy.spin_until_future_complete(self, plugins_future)
 
-        # Call get_active_plugins service synchronously
-        plugins_request = PluginList.Request()
-        plugins_future = self.get_active_plugins_client.call_async(plugins_request)
-        rclpy.spin_until_future_complete(self, plugins_future)
+            if not plugins_future.result():
+                self.get_logger().warn("Failed to retrieve active plugins. Retrying in 1 second.")
+                continue
 
-        if not plugins_future.result():
-            self.get_logger().warn("Failed to retrieve active plugins. Retrying in 1 second.")
-            return
+            active_plugins = plugins_future.result().plugins
 
-        active_plugins = plugins_future.result().plugins
-
-        if self.route_selected and self.check_plugin_status(active_plugins):
-            self.engage_guidance()
-        else:
-            if not self.route_selected:
-                self.get_logger().debug("Could not engage guidance: route not selected")
-            if not self.check_plugin_status(active_plugins):
-                active_names = [plugin.name for plugin in active_plugins]
-                self.get_logger().debug("Could not engage guidance: missing some required plugins")
-                self.get_logger().debug(f"Active plugins: {active_names}")
+            if self.route_selected and self.check_plugin_status(active_plugins):
+                if self.engage_guidance():
+                    break
+            else:
+                if not self.route_selected:
+                    self.get_logger().debug("Could not engage guidance: route not selected")
+                if not self.check_plugin_status(active_plugins):
+                    active_names = [plugin.name for plugin in active_plugins]
+                    self.get_logger().debug("Could not engage guidance: missing some required plugins")
+                    self.get_logger().debug(f"Active plugins: {active_names}")
     
     def engage_guidance(self):
         seconds_passed = 0.0
@@ -115,9 +116,10 @@ class CarmaCarlaGuidance(Node):
 
         if future.result() and future.result().guidance_status:
             self.get_logger().info("Guidance engaged")
-            rclpy.shutdown()  # Stop spinning after successful engagement
+            return True
         else:
             self.get_logger().error("Failed to set guidance status, retrying...")
+            return False
 
     def check_plugin_status(self, active_plugins):
         active_names = [p.name for p in active_plugins if p.available and p.activated]

--- a/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
+++ b/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
@@ -23,10 +23,10 @@ Call Services from CARMA:
 """
 import rclpy
 from rclpy.node import Node
-import rospy
-import sys
+
 import ast
 import time
+
 from cav_msgs.msg import RouteEvent
 from cav_msgs.msg import Plugin
 from cav_srvs.srv import SetGuidanceActive, PluginList
@@ -131,113 +131,3 @@ class CarmaCarlaGuidance(Node):
         if msg.event == RouteEvent.ROUTE_SELECTED or msg.event == RouteEvent.ROUTE_STARTED:
             self.get_logger().info("Route Selected")
             self.route_selected = True
-    
-route_selected = False
-
-def route_event_callback(route_event_msg):
-    """
-    callback for route event subscribing from CARMA
-    guidance_state_msg type:
-        cav_msgs::GuidanceState
-    """
-
-    global route_selected
-    if route_event_msg.event == RouteEvent.ROUTE_SELECTED or route_event_msg.event == RouteEvent.ROUTE_STARTED:
-        rospy.loginfo("Route Selected")
-        route_selected = True
-
-def check_plugin_status(activate_plugins, plugin_list):
-    """
-    check active plugin with plugin list
-    plugin_list: selected plugins + required plugins
-    activate_plugins: the PluginList in /guidance/plugins/get_active_plugins ROS service
-    """
-    activate_plugins_name_list = []
-    for activate_plugin in activate_plugins:
-        if activate_plugin.available and activate_plugin.activated:
-            activate_plugins_name_list.append(activate_plugin.name)
-    if len(list( set(plugin_list) - set(activate_plugins_name_list) )) > 0:
-        # still have some plugin not being activated yet
-        rospy.logwarn("Some plugins are not activated...!")
-        return False
-    else:
-        rospy.loginfo("All plugins activated...!")
-        return True
-
-def initialize():
-    """
-    main loop
-    """
-    rospy.init_node("carma_carla_guidance")
-
-    # initialize ROS topic
-    rospy.Subscriber("/guidance/route_event",RouteEvent, route_event_callback)
-    status_pub = rospy.Publisher('/carla/guidance_bridge_node/active_status', Bool, queue_size=10)
-    # get selected plugins
-    plugin_list_str = rospy.get_param("~selected_plugins")
-    start_delay_in_seconds = rospy.get_param("~start_delay_in_seconds", 15.0)
-    rospy.loginfo("Start delay in seconds: %f", start_delay_in_seconds)
-    plugin_list = ast.literal_eval(plugin_list_str)
-    if len(plugin_list) == 0:
-        rospy.logerr("No input plugin found, please check the config file at /opt/carma/simulation/vehicle_config.json")
-        return
-
-    # initialize ROS service
-    set_guidance_active_serv = rospy.ServiceProxy('/guidance/set_guidance_active', SetGuidanceActive)
-    active_plugins_serv = rospy.ServiceProxy('/guidance/plugins/get_active_plugins', PluginList)
-
-    # make sure to wait for the services to be available
-    rospy.wait_for_service(set_guidance_active_serv.resolved_name)
-    rospy.wait_for_service(active_plugins_serv.resolved_name)
-
-    # initialize ROS topic
-    rospy.loginfo('List of plugins from config: %s', plugin_list)
-
-    while not rospy.is_shutdown():
-        try:
-            active_plugins = active_plugins_serv().plugins
-        except rospy.ServiceException as e:
-            rospy.logwarn(f"Service call to {active_plugins_serv.resolved_name} failed: {e}")
-            rospy.logwarn("Service call can sometimes fail due to ROS, but please make sure the selected plugins are activated. Retrying in 1 second..")
-
-            rospy.sleep(1)
-            continue
-
-        status_msg = True
-        status_pub.publish(status_msg)
-
-        if route_selected and check_plugin_status(active_plugins, plugin_list):
-            seconds_passed = 0.0
-            while (seconds_passed < start_delay_in_seconds):
-                rospy.loginfo("Engaging the guidance in: " + str(start_delay_in_seconds - seconds_passed))
-                seconds_passed += 1.0
-                rospy.sleep(1)
-
-            rospy.loginfo("Attempting to engage guidance")
-            try:
-                resp = set_guidance_active_serv(True)
-            except rospy.ServiceException as e:
-                rospy.logwarn(f"Service call to {set_guidance_active_serv.resolved_name} failed: {e}")
-                rospy.logwarn("Service call can sometimes fail due to ROS, but please make sure the platform has started without any error. Retrying in 1 second..")
-                rospy.sleep(1)
-                continue
-
-            if resp.guidance_status:
-                rospy.loginfo("Guidance engaged")
-                break
-            else:
-                rospy.logerr("Failed to set guidance status")
-                continue
-
-        if not route_selected:
-            rospy.logdebug("Could not engage guidance: route not selected")
-
-        if not check_plugin_status(active_plugins, plugin_list):
-            rospy.logdebug("Could not engage guidance: missing some required plugins")
-            rospy.logdebug(f"Active plugins: {', '.join([plugin.name for plugin in active_plugins])}")
-
-        rospy.sleep(1)
-
-if __name__ == '__main__':
-    rospy.loginfo("carma_carla_guidance starting")
-    initialize()

--- a/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
+++ b/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
@@ -67,11 +67,25 @@ class CarmaCarlaGuidance(Node):
         # Wait for required services
         self.wait_for_services()
 
-        # Start the main loop
+        # Set main loop
         self.timer = self.create_timer(1.0, self.timer_callback)
 
     def timer_callback(self):
-        print()
+        # Publish active status
+        status_msg = Bool()
+        status_msg.data = True
+        self.status_pub.publish(status_msg)
+
+        # Call get_active_plugins service synchronously
+        plugins_request = PluginList.Request()
+        plugins_future = self.get_active_plugins_client.call_async(plugins_request)
+        rclpy.spin_until_future_complete(self, plugins_future)
+
+        if not plugins_future.result():
+            self.get_logger().warn("Failed to retrieve active plugins. Retrying in 1 second.")
+            return
+
+        active_plugins = plugins_future.result().plugins
 
 route_selected = False
 

--- a/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
+++ b/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
@@ -49,6 +49,27 @@ class CarmaCarlaGuidance(Node):
             rclpy.shutdown()
             return
         
+         # route selected state
+        self.route_selected = False
+
+        # Publishers/Subscribers
+        self.status_pub = self.create_publisher(Bool, '/carla/guidance_bridge_node/active_status', 10)
+        self.create_subscription(RouteEvent, '/guidance/route_event', self.route_event_callback, 10)
+
+        # CARMA Services
+        self.set_guidance_active_client = self.create_client(SetGuidanceActive, '/guidance/set_guidance_active')
+        self.get_active_plugins_client = self.create_client(PluginList, '/guidance/plugins/get_active_plugins')
+
+        # Logging
+        self.get_logger().info(f"Start delay in seconds: {self.start_delay}")
+        self.get_logger().info(f"List of plugins from config: {self.plugin_list}")
+
+        # Wait for required services
+        self.wait_for_services()
+
+        # Start the main loop
+        self.timer = self.create_timer(1.0, self.timer_callback)
+
     def timer_callback(self):
         print()
 

--- a/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
+++ b/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
@@ -87,6 +87,15 @@ class CarmaCarlaGuidance(Node):
 
         active_plugins = plugins_future.result().plugins
 
+    def check_plugin_status(self, active_plugins):
+        active_names = [p.name for p in active_plugins if p.available and p.activated]
+        missing = list(set(self.plugin_list) - set(active_names))
+        if len(missing) > 0:
+            self.get_logger().warn(f"Some plugins are not activated: {missing}")
+            return False
+        self.get_logger().info("All plugins activated...!")
+        return True
+
 route_selected = False
 
 def route_event_callback(route_event_msg):

--- a/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
+++ b/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
@@ -73,9 +73,6 @@ class CarmaCarlaGuidance(Node):
         while not self.set_guidance_active_client.wait_for_service(timeout_sec=1.0):
             self.get_logger().info('waiting for set_guidance_active service...')
 
-        # Initially wait for route event callback
-        rclpy.spin_once(self, timeout_sec=2.0)
-
         # Main loop
         while rclpy.ok():
             
@@ -120,7 +117,7 @@ class CarmaCarlaGuidance(Node):
         while seconds_passed < self.start_delay:
             self.get_logger().info(f"Engaging the guidance in: {self.start_delay - seconds_passed:.0f}")
             seconds_passed += 1.0
-            rclpy.spin_once(self, timeout_sec=1.0)
+            time.sleep(1.0)
 
         self.get_logger().info("Attempting to engage guidance")
         try:
@@ -161,6 +158,7 @@ class CarmaCarlaGuidance(Node):
 def main(args=None):
     rclpy.init(args=args)
     print("carma_carla_guidance")
+    node = None
     try:
         node = CarmaCarlaGuidance()
     except KeyboardInterrupt:

--- a/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
+++ b/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-# Copyright (C) 2021 LEIDOS.
+# Copyright (C) 2023 LEIDOS.
+# Migrated to ROS2 under Ryan Fleming @ UGA MSC Lab 2025
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
+++ b/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
@@ -140,7 +140,6 @@ def main(args=None):
     print("carma_carla_guidance")
     try:
         node = CarmaCarlaGuidance()
-        rclpy.spin(node)
     except KeyboardInterrupt:
         if node: node.get_logger().info(f"{node.get_name()} shutting down due to KeyboardInterrupt.")
     except Exception as e:

--- a/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
+++ b/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
@@ -70,6 +70,7 @@ class CarmaCarlaGuidance(Node):
         # store results of service calls
         self.active_plugins = []
         self.guidance_status = False
+        self.selected_plugins_active = False
 
         # Logging
         self.get_logger().info(f"Start delay in seconds: {self.start_delay}")
@@ -91,6 +92,10 @@ class CarmaCarlaGuidance(Node):
         status_msg.data = True
         self.status_pub.publish(status_msg)
 
+        if self.guidance_status:
+                self.destroy_node()
+                rclpy.shutdown()
+
         if not self.plugin_list_future:
             try:
                 request = PluginList.Request()
@@ -107,10 +112,11 @@ class CarmaCarlaGuidance(Node):
         if not self.route_selected:
             self.get_logger().warn("Could not engage guidance: route not selected")
             return
-        elif not self.check_plugin_status(self.active_plugins):
+        elif not self.selected_plugins_active:
             active_names = [plugin.name for plugin in self.active_plugins]
             self.get_logger().warn("Could not engage guidance: missing some required plugins")
             self.get_logger().warn(f"Active plugins: {active_names}")
+            self.plugin_list_future = None
         else:
             if not self.attempting_engage:
                 if self.engage_delay_waited_seconds >= self.start_delay:
@@ -128,15 +134,13 @@ class CarmaCarlaGuidance(Node):
                     return
                 elif not self.engage_guidance_future.done():
                     self.get_logger().info("Waiting for SetEngageGuidance service response...")
-                elif self.guidance_status:
-                    self.destroy_node()
-                    rclpy.shutdown()
     
     def pluginlist_cb(self, future):
         try:
             response = future.result()
             self.active_plugins = response.plugins
             self.get_logger().info("Received active plugins")
+            self.selected_plugins_active = self.check_plugin_status(self.active_plugins)
         except Exception as e:
                 self.get_logger().warn(f"Service call to {self.get_active_plugins_client.srv_name} failed: {e}")
                 self.get_logger().warn("Service call can sometimes fail due to ROS, but please make sure the selected plugins are activated. Retrying in 1 second..")

--- a/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
+++ b/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
@@ -30,6 +30,13 @@ from cav_msgs.msg import RouteEvent
 from cav_msgs.msg import Plugin
 from cav_srvs.srv import SetGuidanceActive, PluginList
 from std_msgs.msg import Bool
+
+class CarmaCarlaGuidance(Node):
+    def __init__():
+        super().__init__('carma_carla_guidance')
+    def timer_callback():
+        print()
+
 route_selected = False
 
 def route_event_callback(route_event_msg):

--- a/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
+++ b/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
@@ -84,9 +84,9 @@ class CarmaCarlaGuidance(Node):
             self.get_logger().info('waiting for set_guidance_active service...')
 
         # create timer
-        self.create_timer(1.0, self.main_cb)
+        self.create_timer(1.0, self.timer_cb)
     
-    def main_cb(self):
+    def timer_cb(self):
         # publish node active status
         status_msg = Bool()
         status_msg.data = True

--- a/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
+++ b/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
@@ -21,6 +21,8 @@ Call Services from CARMA:
     Service: /guidance/set_guidance_active
              /guidance/plugins/get_active_plugins
 """
+import rclpy
+from rclpy.node import Node
 import rospy
 import sys
 import ast

--- a/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
+++ b/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
@@ -66,7 +66,7 @@ class CarmaCarlaGuidance(Node):
         self.get_logger().info(f"List of plugins from config: {self.plugin_list}")
 
         # Wait for required services
-        self.get_logger().info('Waiting for services')
+        self.get_logger().info('Waiting for services...')
         while not self.get_active_plugins_client.wait_for_service(timeout_sec=1.0):
             self.get_logger().info("waiting for get_active_plugins service...")
         while not self.set_guidance_active_client.wait_for_service(timeout_sec=1.0):
@@ -77,7 +77,10 @@ class CarmaCarlaGuidance(Node):
 
         # Main loop
         while rclpy.ok():
-            rclpy.spin_once(self, timeout_sec=1.0)
+            
+            start_time = time.time()
+            while time.time() - start_time < 1.5:
+                rclpy.spin_once(self, timeout_sec=1.0)
             
             # Publish active status
             status_msg = Bool()
@@ -147,7 +150,7 @@ class CarmaCarlaGuidance(Node):
     
     def route_event_callback(self, msg):
         if msg.event == RouteEvent.ROUTE_SELECTED or msg.event == RouteEvent.ROUTE_STARTED:
-            self.get_logger().info("Route Selected")
+            # self.get_logger().info("Route Selected")
             self.route_selected = True
 
 def main(args=None):

--- a/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
+++ b/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
@@ -32,9 +32,24 @@ from cav_srvs.srv import SetGuidanceActive, PluginList
 from std_msgs.msg import Bool
 
 class CarmaCarlaGuidance(Node):
-    def __init__():
+    def __init__(self):
         super().__init__('carma_carla_guidance')
-    def timer_callback():
+
+        # Get Parameters
+        self.declare_parameter("selected_plugins", "[]")
+        self.declare_parameter("start_delay_in_seconds", 15.0)
+        plugin_list_str = self.get_parameter("selected_plugins").get_parameter_value().string_value
+        self.plugin_list = ast.literal_eval(plugin_list_str)
+        self.start_delay = self.get_parameter("start_delay_in_seconds").get_parameter_value().double_value
+
+        if not self.plugin_list:
+            self.get_logger().error(
+                "No input plugin found. Check the config file at /opt/carma/simulation/vehicle_config.json"
+            )
+            rclpy.shutdown()
+            return
+        
+    def timer_callback(self):
         print()
 
 route_selected = False

--- a/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
+++ b/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
@@ -179,7 +179,6 @@ class CarmaCarlaGuidance(Node):
     
     def route_event_callback(self, msg):
         if msg.event == RouteEvent.ROUTE_SELECTED or msg.event == RouteEvent.ROUTE_STARTED:
-            # self.get_logger().info("Route Selected")
             self.route_selected = True
 
 def main(args=None):

--- a/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
+++ b/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
@@ -66,7 +66,8 @@ class CarmaCarlaGuidance(Node):
         self.get_logger().info(f"List of plugins from config: {self.plugin_list}")
 
         # Wait for required services
-        self.wait_for_services()
+        self.set_guidance_active_client.wait_for_service()
+        self.get_active_plugins_client.wait_for_service()
 
         # Set main loop
         self.timer = self.create_timer(1.0, self.timer_callback)
@@ -125,7 +126,7 @@ class CarmaCarlaGuidance(Node):
             return False
         self.get_logger().info("All plugins activated...!")
         return True
-
+    
 route_selected = False
 
 def route_event_callback(route_event_msg):

--- a/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
+++ b/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
@@ -87,6 +87,19 @@ class CarmaCarlaGuidance(Node):
 
         active_plugins = plugins_future.result().plugins
 
+        if self.route_selected and self.check_plugin_status(active_plugins):
+            self.engage_guidance()
+        else:
+            if not self.route_selected:
+                self.get_logger().debug("Could not engage guidance: route not selected")
+            if not self.check_plugin_status(active_plugins):
+                active_names = [plugin.name for plugin in active_plugins]
+                self.get_logger().debug("Could not engage guidance: missing some required plugins")
+                self.get_logger().debug(f"Active plugins: {active_names}")
+    
+    def engage_guidance(self):
+        print()
+
     def check_plugin_status(self, active_plugins):
         active_names = [p.name for p in active_plugins if p.available and p.activated]
         missing = list(set(self.plugin_list) - set(active_names))

--- a/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
+++ b/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
@@ -26,7 +26,6 @@ import rclpy
 from rclpy.node import Node
 
 import ast
-import time
 import traceback
 
 from cav_msgs.msg import RouteEvent
@@ -62,6 +61,16 @@ class CarmaCarlaGuidance(Node):
         self.set_guidance_active_client = self.create_client(SetGuidanceActive, '/guidance/set_guidance_active')
         self.get_active_plugins_client = self.create_client(PluginList, '/guidance/plugins/get_active_plugins')
 
+        # futures for aysnc CARMA service calls
+        self.plugin_list_future = None
+        self.engage_guidance_future = None
+        self.attempting_engage = False
+        self.engage_delay_waited_seconds = 0
+
+        # store results of service calls
+        self.active_plugins = []
+        self.guidance_status = False
+
         # Logging
         self.get_logger().info(f"Start delay in seconds: {self.start_delay}")
         self.get_logger().info(f"List of plugins from config: {self.plugin_list}")
@@ -73,67 +82,82 @@ class CarmaCarlaGuidance(Node):
         while not self.set_guidance_active_client.wait_for_service(timeout_sec=1.0):
             self.get_logger().info('waiting for set_guidance_active service...')
 
-        # Main loop
-        while rclpy.ok():
-            
-            start_time = time.time()
-            while time.time() - start_time < 1.0:
-                rclpy.spin_once(self, timeout_sec=1.0)
-            
-            # Publish active status
-            status_msg = Bool()
-            status_msg.data = True
-            self.status_pub.publish(status_msg)
+        # create timer
+        self.create_timer(1.0, self.main_cb)
+    
+    def main_cb(self):
+        # publish node active status
+        status_msg = Bool()
+        status_msg.data = True
+        self.status_pub.publish(status_msg)
 
-            # Call get_active_plugins service synchronously
+        if not self.plugin_list_future:
             try:
-                plugins_request = PluginList.Request()
-                plugins_future = self.get_active_plugins_client.call_async(plugins_request)
-                rclpy.spin_until_future_complete(self, plugins_future, timeout_sec=2.0)
-
-                if not plugins_future.done():
-                    self.get_logger().warn(f"Service call to {self.get_active_plugins_client.srv_name} timed out.")
-                    continue
-                active_plugins = plugins_future.result().plugins
+                request = PluginList.Request()
+                self.plugin_list_future = self.get_active_plugins_client.call_async(request)
+                self.plugin_list_future.add_done_callback(self.pluginlist_cb)
+                return
             except Exception as e:
+                self.get_logger().warn(f"Failed to send PluginList request: {e}")
+                return
+        elif not self.plugin_list_future.done():
+            self.get_logger().info("Waiting for PluginList service response...")
+            return
+
+        if not self.route_selected:
+            self.get_logger().warn("Could not engage guidance: route not selected")
+            return
+        elif not self.check_plugin_status(self.plugin_list):
+            active_names = [plugin.name for plugin in self.active_plugins]
+            self.get_logger().warn("Could not engage guidance: missing some required plugins")
+            self.get_logger().warn(f"Active plugins: {active_names}")
+        else:
+            if not self.attempting_engage:
+                if self.engage_delay_waited_seconds >= self.start_delay:
+                    self.attempting_engage = True
+                    return
+                self.get_logger().info(f"Engaging the guidance in: {self.start_delay - self.engage_delay_waited_seconds:.0f}")
+                self.engage_delay_waited_seconds += 1.0
+                return
+            else:
+                if not self.engage_guidance_future:
+                    request = SetGuidanceActive.Request()
+                    request.guidance_active = True
+                    self.engage_guidance_future = self.set_guidance_active_client.call_async(request)
+                    self.engage_guidance_future.add_done_callback(self.engage_guidance_cb)
+                    return
+                elif not self.engage_guidance_future.done():
+                    self.get_logger().info("Waiting for SetEngageGuidance service response...")
+                elif self.guidance_status:
+                    self.destroy_node()
+                    rclpy.shutdown()
+    
+    def pluginlist_cb(self, future):
+        try:
+            response = future.result()
+            self.active_plugins = response.plugins
+            self.get_logger().info("Received active plugins")
+        except Exception as e:
                 self.get_logger().warn(f"Service call to {self.get_active_plugins_client.srv_name} failed: {e}")
                 self.get_logger().warn("Service call can sometimes fail due to ROS, but please make sure the selected plugins are activated. Retrying in 1 second..")
-                continue
-
-            if self.route_selected and self.check_plugin_status(active_plugins):
-                if self.engage_guidance():
-                    break
-            else:
-                if not self.route_selected:
-                    self.get_logger().warn("Could not engage guidance: route not selected")
-                if not self.check_plugin_status(active_plugins):
-                    active_names = [plugin.name for plugin in active_plugins]
-                    self.get_logger().warn("Could not engage guidance: missing some required plugins")
-                    self.get_logger().warn(f"Active plugins: {active_names}")
+                self.active_plugins = []
+                self.plugin_list_future = None
     
-    def engage_guidance(self):
-        seconds_passed = 0.0
-        while seconds_passed < self.start_delay:
-            self.get_logger().info(f"Engaging the guidance in: {self.start_delay - seconds_passed:.0f}")
-            seconds_passed += 1.0
-            time.sleep(1.0)
-
-        self.get_logger().info("Attempting to engage guidance")
+    def engage_guidance_cb(self, future):
         try:
-            request = SetGuidanceActive.Request()
-            request.guidance_active = True
-            future = self.set_guidance_active_client.call_async(request)
-            rclpy.spin_until_future_complete(self, future)
-            if future.result() and future.result().guidance_status:
+            result = future.result()
+            if result.guidance_status:
                 self.get_logger().info("Guidance engaged")
-                return True
+                self.guidance_status = True
             else:
-                self.get_logger().error("Failed to set guidance status, retrying...")
-                return False
+                self.get_logger().error("Guidance engagement failed, retrying...")
         except Exception as e:
             self.get_logger().warn(f"Service call to {self.set_guidance_active_client.srv_name} failed: {e}")
-            self.get_logger().warn("Service call can sometimes fail due to ROS, but please make sure the platform has started without any error. Retrying in 1 second..")
-            return False
+            self.get_logger().warn("Service call can sometimes fail due to ROS, but please make sure the platform has started without any error. Retrying in 1 second..")  
+        finally:
+            self.attempting_engage = False
+            self.engage_delay_waited_seconds = 0.0
+            self.engage_guidance_future = None
 
     def check_plugin_status(self, active_plugins):
         """
@@ -160,6 +184,7 @@ def main(args=None):
     node = None
     try:
         node = CarmaCarlaGuidance()
+        rclpy.spin(node)
     except KeyboardInterrupt:
         if node: node.get_logger().info(f"{node.get_name()} shutting down due to KeyboardInterrupt.")
     except Exception as e:

--- a/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
+++ b/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
@@ -66,8 +66,11 @@ class CarmaCarlaGuidance(Node):
         self.get_logger().info(f"List of plugins from config: {self.plugin_list}")
 
         # Wait for required services
-        self.set_guidance_active_client.wait_for_service()
-        self.get_active_plugins_client.wait_for_service()
+        self.get_logger().info('Waiting for services')
+        while not self.get_active_plugins_client.wait_for_service(timeout_sec=1.0):
+            self.get_logger().info("waiting for get_active_plugins service...")
+        while not self.set_guidance_active_client.wait_for_service(timeout_sec=1.0):
+            self.get_logger().info('waiting for set_guidance_active service...')
 
         # Initially wait for route event callback
         rclpy.spin_once(self, timeout_sec=2.0)

--- a/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
+++ b/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
@@ -51,6 +51,9 @@ class CarmaCarlaGuidance(Node):
             )
             return
         
+        # create loop rate timer
+        self.main_loop_rate = self.create_rate(1.0)
+        
          # route selected state
         self.route_selected = False
 
@@ -75,11 +78,6 @@ class CarmaCarlaGuidance(Node):
 
         # Main loop
         while rclpy.ok():
-            
-            start_time = time.time()
-            while time.time() - start_time < 1.0:
-                rclpy.spin_once(self, timeout_sec=1.0)
-            
             # Publish active status
             status_msg = Bool()
             status_msg.data = True
@@ -110,6 +108,9 @@ class CarmaCarlaGuidance(Node):
                     active_names = [plugin.name for plugin in active_plugins]
                     self.get_logger().warn("Could not engage guidance: missing some required plugins")
                     self.get_logger().warn(f"Active plugins: {active_names}")
+            
+            # Sleep for 1 second while allowing callbacks
+            self.main_loop_rate.sleep()
     
     def engage_guidance(self):
         seconds_passed = 0.0

--- a/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
+++ b/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
@@ -41,10 +41,10 @@ class CarmaCarlaGuidance(Node):
         self.declare_parameter("selected_plugins", "[]")
         self.declare_parameter("start_delay_in_seconds", 15.0)
         plugin_list_str = self.get_parameter("selected_plugins").get_parameter_value().string_value
-        self.plugin_list = ast.literal_eval(plugin_list_str)
+        self.selected_plugin_list = ast.literal_eval(plugin_list_str)
         self.start_delay = self.get_parameter("start_delay_in_seconds").get_parameter_value().double_value
 
-        if len(self.plugin_list) == 0 or not self.plugin_list:
+        if len(self.selected_plugin_list) == 0 or not self.selected_plugin_list:
             self.get_logger().error(
                 "No input plugin found. Check the config file at /opt/carma/simulation/vehicle_config.json"
             )
@@ -73,7 +73,7 @@ class CarmaCarlaGuidance(Node):
 
         # Logging
         self.get_logger().info(f"Start delay in seconds: {self.start_delay}")
-        self.get_logger().info(f"List of plugins from config: {self.plugin_list}")
+        self.get_logger().info(f"List of plugins from config: {self.selected_plugin_list}")
 
         # Wait for required services
         self.get_logger().info('Waiting for services...')
@@ -107,7 +107,7 @@ class CarmaCarlaGuidance(Node):
         if not self.route_selected:
             self.get_logger().warn("Could not engage guidance: route not selected")
             return
-        elif not self.check_plugin_status(self.plugin_list):
+        elif not self.check_plugin_status(self.active_plugins):
             active_names = [plugin.name for plugin in self.active_plugins]
             self.get_logger().warn("Could not engage guidance: missing some required plugins")
             self.get_logger().warn(f"Active plugins: {active_names}")
@@ -166,7 +166,7 @@ class CarmaCarlaGuidance(Node):
         activate_plugins: the PluginList in /guidance/plugins/get_active_plugins ROS service
         """
         active_names = [p.name for p in active_plugins if p.available and p.activated]
-        missing = list(set(self.plugin_list) - set(active_names))
+        missing = list(set(self.selected_plugin_list) - set(active_names))
         if len(missing) > 0:
             self.get_logger().warn(f"Some plugins are not activated: {missing}")
             return False

--- a/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
+++ b/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
@@ -93,8 +93,8 @@ class CarmaCarlaGuidance(Node):
         self.status_pub.publish(status_msg)
 
         if self.guidance_status:
-                self.destroy_node()
-                rclpy.shutdown()
+            self.destroy_node()
+            rclpy.shutdown()
 
         if not self.plugin_list_future:
             try:

--- a/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
+++ b/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
@@ -26,6 +26,7 @@ from rclpy.node import Node
 import rospy
 import sys
 import ast
+import time
 from cav_msgs.msg import RouteEvent
 from cav_msgs.msg import Plugin
 from cav_srvs.srv import SetGuidanceActive, PluginList
@@ -98,7 +99,23 @@ class CarmaCarlaGuidance(Node):
                 self.get_logger().debug(f"Active plugins: {active_names}")
     
     def engage_guidance(self):
-        print()
+        seconds_passed = 0.0
+        while seconds_passed < self.start_delay:
+            self.get_logger().info(f"Engaging the guidance in: {self.start_delay - seconds_passed:.0f}")
+            seconds_passed += 1.0
+            time.sleep(1)
+
+        self.get_logger().info("Attempting to engage guidance")
+        request = SetGuidanceActive.Request()
+        request.guidance_active = True
+        future = self.set_guidance_active_client.call_async(request)
+        rclpy.spin_until_future_complete(self, future)
+
+        if future.result() and future.result().guidance_status:
+            self.get_logger().info("Guidance engaged")
+            rclpy.shutdown()  # Stop spinning after successful engagement
+        else:
+            self.get_logger().error("Failed to set guidance status, retrying...")
 
     def check_plugin_status(self, active_plugins):
         active_names = [p.name for p in active_plugins if p.available and p.activated]

--- a/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
+++ b/carma-carla-integration/carma-carla-bridge/src/carma_carla_bridge/carma_carla_guidance
@@ -44,11 +44,10 @@ class CarmaCarlaGuidance(Node):
         self.plugin_list = ast.literal_eval(plugin_list_str)
         self.start_delay = self.get_parameter("start_delay_in_seconds").get_parameter_value().double_value
 
-        if not self.plugin_list:
+        if len(self.plugin_list) == 0 or not self.plugin_list:
             self.get_logger().error(
                 "No input plugin found. Check the config file at /opt/carma/simulation/vehicle_config.json"
             )
-            rclpy.shutdown()
             return
         
          # route selected state
@@ -70,9 +69,12 @@ class CarmaCarlaGuidance(Node):
         self.set_guidance_active_client.wait_for_service()
         self.get_active_plugins_client.wait_for_service()
 
+        # Initially wait for route event callback
+        rclpy.spin_once(self, timeout_sec=2.0)
+
         # Main loop
         while rclpy.ok():
-            rclpy.spin_once(self, timeout_sec=1.5)
+            rclpy.spin_once(self, timeout_sec=1.0)
             
             # Publish active status
             status_msg = Bool()
@@ -80,12 +82,13 @@ class CarmaCarlaGuidance(Node):
             self.status_pub.publish(status_msg)
 
             # Call get_active_plugins service synchronously
-            plugins_request = PluginList.Request()
-            plugins_future = self.get_active_plugins_client.call_async(plugins_request)
-            rclpy.spin_until_future_complete(self, plugins_future)
-
-            if not plugins_future.result():
-                self.get_logger().warn("Failed to retrieve active plugins. Retrying in 1 second.")
+            try:
+                plugins_request = PluginList.Request()
+                plugins_future = self.get_active_plugins_client.call_async(plugins_request)
+                rclpy.spin_until_future_complete(self, plugins_future)
+            except Exception as e:
+                self.get_logger().warn(f"Service call to {self.get_active_plugins_client.srv_name} failed: {e}")
+                self.get_logger().warn("Service call can sometimes fail due to ROS, but please make sure the selected plugins are activated. Retrying in 1 second..")
                 continue
 
             active_plugins = plugins_future.result().plugins
@@ -106,22 +109,31 @@ class CarmaCarlaGuidance(Node):
         while seconds_passed < self.start_delay:
             self.get_logger().info(f"Engaging the guidance in: {self.start_delay - seconds_passed:.0f}")
             seconds_passed += 1.0
-            time.sleep(1)
+            rclpy.spin_once(self, timeout_sec=1.0)
 
         self.get_logger().info("Attempting to engage guidance")
-        request = SetGuidanceActive.Request()
-        request.guidance_active = True
-        future = self.set_guidance_active_client.call_async(request)
-        rclpy.spin_until_future_complete(self, future)
-
-        if future.result() and future.result().guidance_status:
-            self.get_logger().info("Guidance engaged")
-            return True
-        else:
-            self.get_logger().error("Failed to set guidance status, retrying...")
+        try:
+            request = SetGuidanceActive.Request()
+            request.guidance_active = True
+            future = self.set_guidance_active_client.call_async(request)
+            rclpy.spin_until_future_complete(self, future)
+            if future.result() and future.result().guidance_status:
+                self.get_logger().info("Guidance engaged")
+                return True
+            else:
+                self.get_logger().error("Failed to set guidance status, retrying...")
+                return False
+        except Exception as e:
+            self.get_logger().warn(f"Service call to {self.set_guidance_active_client.srv_name} failed: {e}")
+            self.get_logger().warn("Service call can sometimes fail due to ROS, but please make sure the platform has started without any error. Retrying in 1 second..")
             return False
 
     def check_plugin_status(self, active_plugins):
+        """
+        check active plugin with plugin list
+        plugin_list: selected plugins + required plugins
+        activate_plugins: the PluginList in /guidance/plugins/get_active_plugins ROS service
+        """
         active_names = [p.name for p in active_plugins if p.available and p.activated]
         missing = list(set(self.plugin_list) - set(active_names))
         if len(missing) > 0:


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details

## Description

This PR ports the `carma_carla_guidance` node from ROS 1 to ROS 2 (`rclpy`). The node is responsible for monitoring CARMA system readiness (route selection and plugin activation) and engaging guidance once all conditions are satisfied.

Key changes include:
- Migration to `rclpy` Node class structure
- Replacement of `rospy` publishers, subscribers, and service proxies with ROS 2 equivalents
- Asynchronous services managed using internal state tracking and callbacks
- Timer callback used for main loop to allow for the node to be executed by `rclpy.spin()`

## Related GitHub Issue

<!--- Replace this with a link to the relevant GitHub issue once created -->

## Related Jira Key

CDAS-53

## Motivation and Context

This change is part of the broader effort to migrate CARMA simulation tooling to ROS 2. The `carma_carla_guidance` node coordinates simulation guidance startup, ensuring it activates only after route selection and required plugins are online. Porting it to ROS 2 allows it to integrate with updated simulation environments and supports ongoing CARMA platform upgrades.

## How Has This Been Tested?

Testing was performed using mock service nodes that simulate CARMA's plugin system. These mock nodes were configurable to:
- Return plugin lists (with activated or deactivated states)
- Simulate set_guidance_active service call with response indicating success or failure 
- Publish route event ros topic (indicating either route_selected or no route_selected)
Tested the carma_carla_guidance node using these mock services in a ROS 2 workspace:
- Verified set_guidance_active service is called and checked for success
- Verified publication of /carla/guidance_bridge_node/active_status message
Verified retry behavior and error logging when:
- Services are unavailable
- Service callbacks raise internal exceptions
- Services return results indicating an error

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
